### PR TITLE
fix: フィールドマップのキャッシュを廃止

### DIFF
--- a/lib/page-utils.js
+++ b/lib/page-utils.js
@@ -447,36 +447,31 @@ const gotoCreatePage = async (page, domain, appId) => {
   await page.goto(url, { waitUntil: 'networkidle2' })
 }
 
-let fieldMap
-
 const getFieldCodeFromLabel = async (page, fieldLabel) => {
-  await setFieldMap()
+  const fieldMap = await getFieldMap()
   const item = Object.values(fieldMap).find(field => field.label === fieldLabel)
   if (!item) throw new Error(`Cannot find field labeled as '${fieldLabel}'`)
   return item.var
 }
 
 const getFieldIdFromCode = async (page, fieldCode) => {
-  await setFieldMap()
+  const fieldMap = await getFieldMap()
   const item = Object.values(fieldMap).find(field => field.var === fieldCode)
   if (!item) throw new Error(`Cannot find field with code: '${fieldCode}'`)
   return item.id
 }
 
 const getFieldLabelFromId = async (page, fieldId) => {
-  await setFieldMap()
+  const fieldMap = await getFieldMap()
   const item = Object.values(fieldMap).find(field => field.id === fieldId)
   if (!item) throw new Error(`Cannot find field with id: '${fieldId}'`)
   return item.label
 }
 
-const setFieldMap = async () => {
-  if (!fieldMap) {
-    const map = await page.evaluate(async () => {
-      return cybozu.data.page.FORM_DATA.schema.table.fieldList
-    })
-    fieldMap = map
-  }
+const getFieldMap = async () => {
+  return page.evaluate(async () => {
+    return cybozu.data.page.FORM_DATA.schema.table.fieldList
+  })
 }
 
 const getNotifierBodyText = async page => {


### PR DESCRIPTION
- 別のアプリに移動した場合にされるべきキャッシュ削除の処理が欠けている
- 必要な実装が複雑になるので、いったん廃止