### PR TITLE
ginueのバージョンアップ

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-standard": "^4.0.0",
-    "ginue": "^2.1.2",
+    "ginue": "^2.1.3",
     "jest": "^24.8.0",
     "jest-puppeteer": "^4.3.0",
     "netrc-parser": "^3.1.6",


### PR DESCRIPTION
Windows 10、Node v10.16.3環境で動作するようにバージョンアップしてほしいです。
詳細：https://github.com/goqoo-on-kintone/ginue/pull/18